### PR TITLE
ĐOẠN CODE VI PHẠM NGUYÊN TẮC CODE KISS/DRY/YAGNI

### DIFF
--- a/PersonalTaskManagerViolations.java
+++ b/PersonalTaskManagerViolations.java
@@ -1,0 +1,167 @@
+package CNPM;
+
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+public class PersonalTaskManagerViolations {
+
+    private static final String DB_FILE_PATH = "tasks_database.json";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    // Phương thức trợ giúp để tải dữ liệu (sẽ được gọi lặp lại)
+    private static JSONArray loadTasksFromDb() {
+        JSONParser parser = new JSONParser();
+        try (FileReader reader = new FileReader(DB_FILE_PATH)) {
+            Object obj = parser.parse(reader);
+            if (obj instanceof JSONArray) {
+                return (JSONArray) obj;
+            }
+        } catch (IOException | ParseException e) {
+            System.err.println("Lỗi khi đọc file database: " + e.getMessage());
+        }
+        return new JSONArray();
+    }
+
+    // Phương thức trợ giúp để lưu dữ liệu
+    private static void saveTasksToDb(JSONArray tasksData) {
+        try (FileWriter file = new FileWriter(DB_FILE_PATH)) {
+            file.write(tasksData.toJSONString());
+            file.flush();
+        } catch (IOException e) {
+            System.err.println("Lỗi khi ghi vào file database: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Chức năng thêm nhiệm vụ mới
+     *
+     * @param title Tiêu đề nhiệm vụ.
+     * @param description Mô tả nhiệm vụ.
+     * @param dueDateStr Ngày đến hạn (định dạng YYYY-MM-DD).
+     * @param priorityLevel Mức độ ưu tiên ("Thấp", "Trung bình", "Cao").
+     * @param isRecurring Boolean có phải là nhiệm vụ lặp lại không.
+     * @return JSONObject của nhiệm vụ đã thêm, hoặc null nếu có lỗi.
+     */
+    public JSONObject addNewTaskWithViolations(String title, String description,
+                                                String dueDateStr, String priorityLevel,
+                                                boolean isRecurring) {
+
+        if (title == null || title.trim().isEmpty()) {
+            System.out.println("Lỗi: Tiêu đề không được để trống.");
+            return null;
+        }
+        if (dueDateStr == null || dueDateStr.trim().isEmpty()) {
+            System.out.println("Lỗi: Ngày đến hạn không được để trống.");
+            return null;
+        }
+        LocalDate dueDate;
+        try {
+            dueDate = LocalDate.parse(dueDateStr, DATE_FORMATTER);
+        } catch (DateTimeParseException e) {
+            System.out.println("Lỗi: Ngày đến hạn không hợp lệ. Vui lòng sử dụng định dạng YYYY-MM-DD.");
+            return null;
+        }
+        String[] validPriorities = {"Thấp", "Trung bình", "Cao"};
+        boolean isValidPriority = false;
+        for (String validP : validPriorities) {
+            if (validP.equals(priorityLevel)) {
+                isValidPriority = true;
+                break;
+            }
+        }
+        if (!isValidPriority) {
+            System.out.println("Lỗi: Mức độ ưu tiên không hợp lệ. Vui lòng chọn từ: Thấp, Trung bình, Cao.");
+            return null;
+        }
+
+        // Tải dữ liệu
+        JSONArray tasks = loadTasksFromDb();
+
+        // Kiểm tra trùng lặp
+        for (Object obj : tasks) {
+            JSONObject existingTask = (JSONObject) obj;
+            if (existingTask.get("title").toString().equalsIgnoreCase(title) &&
+                existingTask.get("due_date").toString().equals(dueDate.format(DATE_FORMATTER))) {
+                System.out.println(String.format("Lỗi: Nhiệm vụ '%s' đã tồn tại với cùng ngày đến hạn.", title));
+                return null;
+            }
+        }
+
+        String taskId = UUID.randomUUID().toString(); // YAGNI: Có thể dùng số nguyên tăng dần đơn giản hơn.
+
+        JSONObject newTask = new JSONObject();
+        newTask.put("id", taskId);
+        newTask.put("title", title);
+        newTask.put("description", description);
+        newTask.put("due_date", dueDate.format(DATE_FORMATTER));
+        newTask.put("priority", priorityLevel);
+        newTask.put("status", "Chưa hoàn thành");
+        newTask.put("created_at", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
+        newTask.put("last_updated_at", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
+        newTask.put("is_recurring", isRecurring); // YAGNI: Thêm thuộc tính này dù chưa có chức năng xử lý nhiệm vụ lặp lại
+        if (isRecurring) {
+
+            newTask.put("recurrence_pattern", "Chưa xác định");
+        }
+
+        tasks.add(newTask);
+
+        // Lưu dữ liệu
+        saveTasksToDb(tasks);
+
+        System.out.println(String.format("Đã thêm nhiệm vụ mới thành công với ID: %s", taskId));
+        return newTask;
+    }
+
+    public static void main(String[] args) {
+        PersonalTaskManagerViolations manager = new PersonalTaskManagerViolations();
+        System.out.println("\nThêm nhiệm vụ hợp lệ:");
+        manager.addNewTaskWithViolations(
+            "Mua sách",
+            "Sách Công nghệ phần mềm.",
+            "2025-07-20",
+            "Cao",
+            false
+        );
+
+        System.out.println("\nThêm nhiệm vụ trùng lặp (minh họa DRY - lặp lại code đọc/ghi DB và kiểm tra trùng):");
+        manager.addNewTaskWithViolations(
+            "Mua sách",
+            "Sách Công nghệ phần mềm.",
+            "2025-07-20",
+            "Cao",
+            false
+        );
+
+        System.out.println("\nThêm nhiệm vụ lặp lại (minh họa YAGNI - thêm tính năng không cần thiết ngay):");
+        manager.addNewTaskWithViolations(
+            "Tập thể dục",
+            "Tập gym 1 tiếng.",
+            "2025-07-21",
+            "Trung bình",
+            true 
+        );
+
+        System.out.println("\nThêm nhiệm vụ với tiêu đề rỗng:");
+        manager.addNewTaskWithViolations(
+            "",
+            "Nhiệm vụ không có tiêu đề.",
+            "2025-07-22",
+            "Thấp",
+            false
+        );
+    }
+}
+

--- a/Task.java
+++ b/Task.java
@@ -1,0 +1,36 @@
+package CNPM;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+import org.json.simple.JSONObject;
+
+public class Task {
+
+    public static JSONObject createTask(String title, String description, LocalDate dueDate,
+                                         String priorityLevel, boolean isRecurring) {
+
+        String taskId = UUID.randomUUID().toString();
+        JSONObject newTask = new JSONObject();
+
+        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        newTask.put("id", taskId);
+        newTask.put("title", title);
+        newTask.put("description", description);
+        newTask.put("due_date", dueDate.format(dateFormatter));
+        newTask.put("priority", priorityLevel);
+        newTask.put("status", "Chưa hoàn thành");
+        newTask.put("created_at", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
+        newTask.put("last_updated_at", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
+        newTask.put("is_recurring", isRecurring);
+
+        if (isRecurring) {
+            newTask.put("recurrence_pattern", "Chưa xác định");
+        }
+
+        return newTask;
+    }
+}
+

--- a/TaskDatabase.java
+++ b/TaskDatabase.java
@@ -1,0 +1,35 @@
+package CNPM;
+
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import org.json.simple.JSONArray;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+public class TaskDatabase {
+
+    public static final String DB_FILE_PATH = "tasks_database.json";
+
+    public static JSONArray loadTasksFromDb() {
+        JSONParser parser = new JSONParser();
+        try (FileReader reader = new FileReader(DB_FILE_PATH)) {
+            Object obj = parser.parse(reader);
+            if (obj instanceof JSONArray) {
+                return (JSONArray) obj;
+            }
+        } catch (IOException | ParseException e) {
+            System.err.println("Lỗi khi đọc file database: " + e.getMessage());
+        }
+        return new JSONArray();
+    }
+
+    public static void saveTasksToDb(JSONArray tasksData) {
+        try (FileWriter file = new FileWriter(DB_FILE_PATH)) {
+            file.write(tasksData.toJSONString());
+            file.flush();
+        } catch (IOException e) {
+            System.err.println("Lỗi khi ghi vào file database: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Code ban đầu của PersonalTaskManager vi phạm nguyên tắc KISS, DRY, và YAGNI:
- KISS (Keep It Simple, Stupid) Logic xử lý dữ liệu và thao tác file bị dàn trải, phức tạp hóa việc đọc/ghi JSON, khó bảo trì về sau.

- DRY (Don't Repeat Yourself) Nhiều đoạn code lặp lại việc chuyển đổi giữa Task và JSONObject. Việc đọc ghi file JSON cũng bị lặp ở nhiều hàm.

- YAGNI (You Aren’t Gonna Need It) Thao tác với toàn bộ file dữ liệu cho mỗi lần thêm/sửa/xóa dù chỉ thay đổi 1 task. Một số logic định dạng ngày tháng dư thừa.

Thay đổi
Tách riêng class TaskDatabase để quản lý thao tác đọc/ghi file JSON. Tách logic chuyển đổi Task ↔ JSONObject vào trong class Task với hàm toJson() và fromJson(). Đơn giản hóa code, loại bỏ các đoạn xử lý dư thừa, giảm lặp code.