### PR TITLE
Code refactor-Xử lý Dữ Liệu

### DIFF
--- a/Task.java
+++ b/Task.java
@@ -1,4 +1,4 @@
-package CNPM;
+package CNPM2;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -8,18 +8,15 @@ import org.json.simple.JSONObject;
 
 public class Task {
 
-    public static JSONObject createTask(String title, String description, LocalDate dueDate,
-                                         String priorityLevel, boolean isRecurring) {
-
+    public static JSONObject createTask(String title, String description, LocalDate dueDate, String priorityLevel, boolean isRecurring) {
         String taskId = UUID.randomUUID().toString();
         JSONObject newTask = new JSONObject();
-
-        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
         newTask.put("id", taskId);
         newTask.put("title", title);
         newTask.put("description", description);
-        newTask.put("due_date", dueDate.format(dateFormatter));
+        newTask.put("due_date", dueDate.format(formatter));
         newTask.put("priority", priorityLevel);
         newTask.put("status", "Chưa hoàn thành");
         newTask.put("created_at", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
@@ -33,4 +30,3 @@ public class Task {
         return newTask;
     }
 }
-

--- a/TaskDatabase.java
+++ b/TaskDatabase.java
@@ -1,4 +1,4 @@
-package CNPM;
+package CNPM2;
 
 import java.io.FileReader;
 import java.io.FileWriter;
@@ -8,10 +8,9 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
 public class TaskDatabase {
+    private static final String DB_FILE_PATH = "tasks_database.json";
 
-    public static final String DB_FILE_PATH = "tasks_database.json";
-
-    public static JSONArray loadTasksFromDb() {
+    public static JSONArray loadTasks() {
         JSONParser parser = new JSONParser();
         try (FileReader reader = new FileReader(DB_FILE_PATH)) {
             Object obj = parser.parse(reader);
@@ -24,9 +23,9 @@ public class TaskDatabase {
         return new JSONArray();
     }
 
-    public static void saveTasksToDb(JSONArray tasksData) {
+    public static void saveTasks(JSONArray tasks) {
         try (FileWriter file = new FileWriter(DB_FILE_PATH)) {
-            file.write(tasksData.toJSONString());
+            file.write(tasks.toJSONString());
             file.flush();
         } catch (IOException e) {
             System.err.println("Lỗi khi ghi vào file database: " + e.getMessage());


### PR DESCRIPTION
Details:
Task.java
Thêm phương thức toJson() để chuyển Task thành JSONObject. Thêm phương thức fromJson(JSONObject obj) để chuyển JSONObject thành Task. Giúp loại bỏ việc lặp lại code chuyển đổi khi đọc/ghi file.

TaskDatabase.java
Tách toàn bộ chức năng đọc/ghi file JSON từ PersonalTaskManager sang TaskDatabase. Gom toàn bộ thao tác thêm, sửa, xóa task vào một nơi duy nhất, đảm bảo dễ quản lý và bảo trì. Sử dụng các hàm chuyển đổi từ Task.java để tránh trùng lặp.